### PR TITLE
collapse segment header for same speaker

### DIFF
--- a/src/components/FullTranscript.js
+++ b/src/components/FullTranscript.js
@@ -48,7 +48,6 @@ class TranscriptSegment extends Component {
     const { segment, onSelectWord, previousSegment, endTime } = this.props;
     const { speakerInfo } = segment;
 
-    let showSpeaker = false;
     let isPrevSpeaker = false;
     let color;
     if (speakerInfo) {
@@ -59,7 +58,7 @@ class TranscriptSegment extends Component {
           ? maleColorScale(speakerInfo.id)
           : femaleColorScale(speakerInfo.id);
     }
-    showSpeaker = !isPrevSpeaker && speakerInfo;
+    const showSpeaker = !isPrevSpeaker && speakerInfo;
 
     return (
       <div className="TranscriptSegment">

--- a/src/components/FullTranscript.js
+++ b/src/components/FullTranscript.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import cx from 'classnames';
 import { scaleOrdinal } from 'd3';
 
-import { formatTime, renderWord } from '../util';
+import { formatTime, renderWord, getSpeakerEndTime } from '../util';
 
 import './FullTranscript.css';
 
@@ -29,11 +29,13 @@ class FullTranscript extends Component {
 
     return (
       <div className="FullTranscript">
-        {transcript.segments.map((segment, i) => (
+        {transcript.segments.map((segment, i, array) => (
           <TranscriptSegment
             key={i}
             segment={segment}
             onSelectWord={onSelectWord}
+            previousSegment={i > 0 ? array[i - 1] : null}
+            endTime={getSpeakerEndTime(array, i)}
           />
         ))}
       </div>
@@ -43,8 +45,9 @@ class FullTranscript extends Component {
 
 class TranscriptSegment extends Component {
   render() {
-    const { segment, onSelectWord } = this.props;
+    const { segment, onSelectWord, previousSegment, endTime } = this.props;
     const { speakerInfo } = segment;
+
     let color;
     if (speakerInfo) {
       color =
@@ -53,33 +56,42 @@ class TranscriptSegment extends Component {
           : femaleColorScale(speakerInfo.id);
     }
 
+    let newSpeaker = true;
+    if (previousSegment) {
+      const { speakerInfo: previousSpeakerInfo } = previousSegment;
+      if (previousSpeakerInfo.id === speakerInfo.id) {
+        newSpeaker = false;
+      }
+    }
+
     return (
       <div className="TranscriptSegment">
         <div className="segment-header">
-          {speakerInfo && (
-            <span
-              className={cx('segment-speaker-avatar', {
-                'male-speaker': speakerInfo.gender === 'M',
-                'female-speaker': speakerInfo.gender === 'F',
-              })}
-              style={{ backgroundColor: color }}
-            >
-              S{speakerInfo.id}
-            </span>
-          )}
-          {speakerInfo && (
-            <span
-              className={cx('segment-speaker', {
-                'male-speaker': speakerInfo.gender === 'M',
-                'female-speaker': speakerInfo.gender === 'F',
-              })}
-            >
-              Speaker {speakerInfo.id}
-            </span>
-          )}
-          <span className="segment-time">
-            {formatTime(segment.time)}–{formatTime(segment.endTime)}
-          </span>
+          {speakerInfo &&
+            newSpeaker && (
+              <React.Fragment>
+                <span
+                  className={cx('segment-speaker-avatar', {
+                    'male-speaker': speakerInfo.gender === 'M',
+                    'female-speaker': speakerInfo.gender === 'F',
+                  })}
+                  style={{ backgroundColor: color }}
+                >
+                  S{speakerInfo.id}
+                </span>
+                <span
+                  className={cx('segment-speaker', {
+                    'male-speaker': speakerInfo.gender === 'M',
+                    'female-speaker': speakerInfo.gender === 'F',
+                  })}
+                >
+                  Speaker {speakerInfo.id}
+                </span>
+                <span className="segment-time">
+                  {formatTime(segment.time)}–{formatTime(endTime)}
+                </span>
+              </React.Fragment>
+            )}
         </div>
         {segment.words.map((word, i) => [
           <React.Fragment key={i}>

--- a/src/components/FullTranscript.js
+++ b/src/components/FullTranscript.js
@@ -29,13 +29,13 @@ class FullTranscript extends Component {
 
     return (
       <div className="FullTranscript">
-        {transcript.segments.map((segment, i, array) => (
+        {transcript.segments.map((segment, i, allSegments) => (
           <TranscriptSegment
             key={i}
             segment={segment}
             onSelectWord={onSelectWord}
-            previousSegment={i > 0 ? array[i - 1] : null}
-            endTime={getSpeakerEndTime(array, i)}
+            previousSegment={allSegments[i - 1]}
+            endTime={getSpeakerEndTime(allSegments, i)}
           />
         ))}
       </div>
@@ -48,50 +48,48 @@ class TranscriptSegment extends Component {
     const { segment, onSelectWord, previousSegment, endTime } = this.props;
     const { speakerInfo } = segment;
 
+    let showSpeaker = false;
+    let isPrevSpeaker = false;
     let color;
     if (speakerInfo) {
+      isPrevSpeaker =
+        previousSegment && previousSegment.speakerInfo.id === speakerInfo.id;
       color =
         speakerInfo.gender === 'M'
           ? maleColorScale(speakerInfo.id)
           : femaleColorScale(speakerInfo.id);
     }
-
-    let newSpeaker = true;
-    if (previousSegment) {
-      const { speakerInfo: previousSpeakerInfo } = previousSegment;
-      if (previousSpeakerInfo.id === speakerInfo.id) {
-        newSpeaker = false;
-      }
-    }
+    showSpeaker = !isPrevSpeaker && speakerInfo;
 
     return (
       <div className="TranscriptSegment">
         <div className="segment-header">
-          {speakerInfo &&
-            newSpeaker && (
-              <React.Fragment>
-                <span
-                  className={cx('segment-speaker-avatar', {
-                    'male-speaker': speakerInfo.gender === 'M',
-                    'female-speaker': speakerInfo.gender === 'F',
-                  })}
-                  style={{ backgroundColor: color }}
-                >
-                  S{speakerInfo.id}
-                </span>
-                <span
-                  className={cx('segment-speaker', {
-                    'male-speaker': speakerInfo.gender === 'M',
-                    'female-speaker': speakerInfo.gender === 'F',
-                  })}
-                >
-                  Speaker {speakerInfo.id}
-                </span>
-                <span className="segment-time">
-                  {formatTime(segment.time)}–{formatTime(endTime)}
-                </span>
-              </React.Fragment>
-            )}
+          {showSpeaker && (
+            <React.Fragment>
+              <span
+                className={cx('segment-speaker-avatar', {
+                  'male-speaker': speakerInfo.gender === 'M',
+                  'female-speaker': speakerInfo.gender === 'F',
+                })}
+                style={{ backgroundColor: color }}
+              >
+                S{speakerInfo.id}
+              </span>
+              <span
+                className={cx('segment-speaker', {
+                  'male-speaker': speakerInfo.gender === 'M',
+                  'female-speaker': speakerInfo.gender === 'F',
+                })}
+              >
+                Speaker {speakerInfo.id}
+              </span>
+            </React.Fragment>
+          )}
+          {!isPrevSpeaker && (
+            <span className="segment-time">
+              {formatTime(segment.time)}–{formatTime(endTime)}
+            </span>
+          )}
         </div>
         {segment.words.map((word, i) => [
           <React.Fragment key={i}>

--- a/src/util.js
+++ b/src/util.js
@@ -259,22 +259,24 @@ export function topTermsFromTranscript(transcript, filterStopWords, limit) {
  * Finds the actual end time for when a speaker stops talking (collapses multiple of the same speaker in a row into one end time)
  */
 export function getSpeakerEndTime(segments, segmentIndex) {
-  let initialSegment = segments[segmentIndex];
-  let { endTime } = initialSegment;
+  // get the initial segment's speaker ID
+  const initialSegment = segments[segmentIndex];
+  const { speakerInfo: initialSpeakerInfo } = initialSegment;
 
-  for (let i = segmentIndex; i < segments.length - 1; i++) {
-    const currentSegment = segments[i];
-    const { id: currentSpeakerId } = currentSegment.speakerInfo;
-    endTime = currentSegment.endTime;
-
-    let nextSegment = segments[i + 1];
-    if (
-      !nextSegment.speakerInfo ||
-      nextSegment.speakerInfo.id !== currentSpeakerId
-    ) {
-      return endTime;
+  if (initialSpeakerInfo) {
+    const { id: initialSpeakerId } = initialSpeakerInfo;
+    // iterate to see how many more segments this speaker speaks for
+    for (let i = segmentIndex; i < segments.length - 1; i++) {
+      const nextSegment = segments[i + 1];
+      // if a new speaker appears, return this segment's end time
+      if (
+        !nextSegment.speakerInfo ||
+        nextSegment.speakerInfo.id !== initialSpeakerId
+      ) {
+        return segments[i].endTime;
+      }
     }
   }
-
-  return endTime;
+  // if there is no speaker info or it's the last clip, just return this segment's time
+  return initialSegment.endTime;
 }

--- a/src/util.js
+++ b/src/util.js
@@ -254,3 +254,32 @@ export function topTermsFromTranscript(transcript, filterStopWords, limit) {
 
   return filteredTerms;
 }
+
+/**
+ * Finds the actual end time for when a speaker stops talking (collapses multiple of the same speaker in a row into one end time)
+ */
+export function getSpeakerEndTime(segments, segmentId) {
+  // get current segment info
+  const currentSegment = segments[segmentId];
+  if (currentSegment.speakerInfo) {
+    const { id: currentSpeakerId } = currentSegment.speakerInfo;
+    let { endTime } = currentSegment;
+
+    // get next segment info
+    if (segmentId < segments.length - 1) {
+      const nextSegment = segments[segmentId + 1];
+      if (nextSegment.speakerInfo) {
+        const { id: nextSpeakerId } = nextSegment.speakerInfo;
+        // if it's the same speaker, call this function again but on the next segment
+        if (currentSpeakerId == nextSpeakerId) {
+          return getSpeakerEndTime(segments, segmentId + 1);
+        } else {
+          // if it's a new speaker, return this segment's end time
+          return endTime;
+        }
+      }
+    }
+  }
+
+  return null;
+}

--- a/src/util.js
+++ b/src/util.js
@@ -258,28 +258,23 @@ export function topTermsFromTranscript(transcript, filterStopWords, limit) {
 /**
  * Finds the actual end time for when a speaker stops talking (collapses multiple of the same speaker in a row into one end time)
  */
-export function getSpeakerEndTime(segments, segmentId) {
-  // get current segment info
-  const currentSegment = segments[segmentId];
-  if (currentSegment.speakerInfo) {
-    const { id: currentSpeakerId } = currentSegment.speakerInfo;
-    let { endTime } = currentSegment;
+export function getSpeakerEndTime(segments, segmentIndex) {
+  let initialSegment = segments[segmentIndex];
+  let { endTime } = initialSegment;
 
-    // get next segment info
-    if (segmentId < segments.length - 1) {
-      const nextSegment = segments[segmentId + 1];
-      if (nextSegment.speakerInfo) {
-        const { id: nextSpeakerId } = nextSegment.speakerInfo;
-        // if it's the same speaker, call this function again but on the next segment
-        if (currentSpeakerId == nextSpeakerId) {
-          return getSpeakerEndTime(segments, segmentId + 1);
-        } else {
-          // if it's a new speaker, return this segment's end time
-          return endTime;
-        }
-      }
+  for (let i = segmentIndex; i < segments.length - 1; i++) {
+    const currentSegment = segments[i];
+    const { id: currentSpeakerId } = currentSegment.speakerInfo;
+    endTime = currentSegment.endTime;
+
+    let nextSegment = segments[i + 1];
+    if (
+      !nextSegment.speakerInfo ||
+      nextSegment.speakerInfo.id !== currentSpeakerId
+    ) {
+      return endTime;
     }
   }
 
-  return null;
+  return endTime;
 }


### PR DESCRIPTION
Makes text that falls under the same speaker look like this:
![image](https://user-images.githubusercontent.com/24641006/41623673-7ad9f954-73e1-11e8-92ef-3ed62d63910c.png)

Instead of:
![image](https://user-images.githubusercontent.com/24641006/41623693-861fdcca-73e1-11e8-8d48-33504fcd7a69.png)
